### PR TITLE
Fix missing semicolon from variable lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 
 will be converted to
 ```sass
-  $a-b : 100px
-  $a-c-d : 99
+  $a-b : 100px;
+  $a-c-d : 99;
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function SassImports(content) {
     obj.paths().forEach(function traverseJSONPAth(jsonPath) {
       var val = obj.get(jsonPath);
       if (typeof val !== 'object') {
-        imports.push('$'+jsonPath.join('-') + ' : ' + val);
+        imports.push('$'+jsonPath.join('-') + ': ' + val + ';');
       }
     });
   });


### PR DESCRIPTION
Top-level variable binding must be terminated by ';'. Simple fix.
